### PR TITLE
Update examples to use default pipe (high-performance architecture)

### DIFF
--- a/java-example/README.md
+++ b/java-example/README.md
@@ -1,19 +1,32 @@
 # Java Snowpipe Streaming SDK Example
 
-This example demonstrates how to use the Snowflake Streaming Ingest SDK in Java to ingest data into Snowflake in real-time.
+This example demonstrates how to use the Snowflake Streaming Ingest SDK in Java to ingest data into Snowflake in real-time using the [high-performance architecture](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-overview) and default pipe.
 
 ## Prerequisites
 
 - Java 11 or higher
 - Maven 3.6 or higher
 - A Snowflake account with appropriate permissions
-- A Snowflake table to ingest data into
+- RSA key-pair authentication configured
 
 ## Setup
 
-### 1. Create a Snowflake Table
+### 1. Generate RSA Key Pair
 
-Before running the example, create a table in your Snowflake account:
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+Register the public key with your Snowflake user:
+
+```sql
+ALTER USER MY_USER SET RSA_PUBLIC_KEY='<contents of rsa_key.pub, without header/footer>';
+```
+
+### 2. Create a Snowflake Table
+
+Create a target table in your Snowflake account:
 
 ```sql
 CREATE OR REPLACE TABLE MY_DATABASE.MY_SCHEMA.MY_TABLE (
@@ -23,39 +36,31 @@ CREATE OR REPLACE TABLE MY_DATABASE.MY_SCHEMA.MY_TABLE (
 );
 ```
 
-### 2. Create a Snowpipe
-
-Create a Snowpipe for streaming ingestion:
-
-```sql
-CREATE OR REPLACE PIPE MY_DATABASE.MY_SCHEMA.MY_PIPE 
-AS COPY INTO MY_DATABASE.MY_SCHEMA.MY_TABLE 
-FROM @%MY_TABLE;
-```
+No `CREATE PIPE` is needed — the high-performance architecture automatically creates a **default pipe** named `MY_TABLE-STREAMING` when you first open a channel.
 
 ### 3. Configure Authentication
 
-Create a `profile.json` file in the root of the `java-example` directory with your Snowflake credentials. You can use `profile.json.example` as a template:
+Create a `profile.json` file in the `java-example` directory using `profile.json.example` as a template:
 
 ```json
 {
-  "account": "<account>",
+  "account": "<account_identifier>",
   "user": "your_username",
-  "url": "https://<account>.<locator>.snowflakecomputing.com:443",
-  "private_key": "your_private_key_path_or_content",
+  "url": "https://<account_identifier>.snowflakecomputing.com:443",
+  "private_key_file": "rsa_key.p8",
   "role": "your_role"
 }
 ```
 
-**Note:** For production use, consider using environment variables or a secure credential manager instead of storing credentials in a file.
+**Note:** Use `private_key_file` to reference the key file path. For production, consider using a secure credential manager.
 
 ### 4. Update Configuration
 
-Edit `src/main/java/com/snowflake/example/StreamingIngestExample.java` and update the following values to match your Snowflake setup:
+Edit `src/main/java/com/snowflake/example/StreamingIngestExample.java` and update the constants at the top of the class:
 
-- `MY_DATABASE` - Your database name
-- `MY_SCHEMA` - Your schema name  
-- `MY_PIPE` - Your pipe name
+- `DATABASE` - Your database name
+- `SCHEMA` - Your schema name
+- `TABLE` - Your table name (the pipe name is derived automatically as `<TABLE>-STREAMING`)
 
 ## Build
 
@@ -69,22 +74,16 @@ mvn clean package
 mvn exec:java
 ```
 
-Or run directly:
-
-```bash
-mvn clean compile exec:java -Dexec.mainClass="com.snowflake.example.StreamingIngestExample"
-```
-
 ## What the Example Does
 
-1. **Creates a Streaming Ingest Client** - Initializes a connection to Snowflake using the credentials from `profile.json`
-2. **Opens a Channel** - Creates a channel for streaming data into the specified pipe
-3. **Ingests Data** - Sends 100,000 rows of sample data with three columns:
+1. **Creates a Streaming Ingest Client** - Connects to Snowflake using credentials from `profile.json`
+2. **Opens a Channel** - Creates a channel on the default pipe (`MY_TABLE-STREAMING`)
+3. **Ingests Data** - Streams 100,000 rows with columns matched by name (MATCH_BY_COLUMN_NAME):
    - `c1`: Integer counter
    - `c2`: String representation of the counter
    - `ts`: Current timestamp
-4. **Waits for Completion** - Polls the channel status to ensure all data has been committed
-5. **Closes Resources** - Properly closes the channel and client
+4. **Waits for Completion** - Polls the channel status until all data is committed
+5. **Closes Resources** - Properly closes the channel and client via try-with-resources
 
 ## Expected Output
 
@@ -104,11 +103,12 @@ Data ingestion completed
 ## Troubleshooting
 
 - **Connection Issues**: Verify your `profile.json` credentials and network connectivity to Snowflake
-- **Permission Errors**: Ensure your user has the necessary privileges to write to the specified database, schema, and pipe
-- **Table Not Found**: Verify the table exists and the pipe is configured correctly
+- **Permission Errors**: Ensure your role has the necessary privileges on the database, schema, and table
+- **Table Not Found**: Verify the table exists — the default pipe is created automatically
+- **VARIANT Columns**: If using VARIANT columns, pass data as a Java `Map`, not a JSON string
 
 ## Additional Resources
 
-- [Snowflake Streaming Ingest SDK Documentation](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming)
-- [Snowflake Snowpipe Streaming SDK on Maven Central](https://repo1.maven.org/maven2/com/snowflake/snowpipe-streaming/)
-
+- [High-Performance Streaming Overview](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-overview)
+- [Getting Started Guide](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-getting-started)
+- [Snowpipe Streaming SDK on Maven Central](https://repo1.maven.org/maven2/com/snowflake/snowpipe-streaming/)

--- a/java-example/pom.xml
+++ b/java-example/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.snowflake</groupId>
             <artifactId>snowpipe-streaming</artifactId>
-            <version>1.0.1</version>
+            <version>1.3.0</version>
         </dependency>
 
         <!-- Jackson for JSON processing -->

--- a/java-example/profile.json.example
+++ b/java-example/profile.json.example
@@ -1,7 +1,7 @@
 {
-  "account": "<account>",
+  "account": "<account_identifier>",
   "user": "your_username",
-  "url": "https://<account>.<locator>.snowflakecomputing.com:443",
-  "private_key": "path_to_private_key.pem"
+  "url": "https://<account_identifier>.snowflakecomputing.com:443",
+  "private_key_file": "rsa_key.p8",
+  "role": "your_role"
 }
-

--- a/java-example/src/main/java/com/snowflake/example/StreamingIngestExample.java
+++ b/java-example/src/main/java/com/snowflake/example/StreamingIngestExample.java
@@ -16,14 +16,12 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Example demonstrating how to use the Snowflake Streaming Ingest SDK.
- * 
- * This example shows how to:
- * 1. Create a Snowflake Streaming Ingest Client
- * 2. Open a channel for data ingestion
- * 3. Ingest rows of data
- * 4. Wait for ingestion to complete
- * 5. Close resources properly
+ * Example demonstrating how to use the Snowflake Streaming Ingest SDK
+ * with the high-performance architecture and default pipe.
+ *
+ * The default pipe is automatically created by Snowflake when you first
+ * open a channel. No CREATE PIPE DDL is required. The default pipe name
+ * follows the convention: {@code <TABLE_NAME>-STREAMING}
  */
 public class StreamingIngestExample {
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -31,6 +29,14 @@ public class StreamingIngestExample {
     private static final int MAX_ROWS = 100_000;
     private static final int POLL_ATTEMPTS = 30;
     private static final long POLL_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
+
+    // Replace these with your Snowflake object names
+    private static final String DATABASE = "MY_DATABASE";
+    private static final String SCHEMA = "MY_SCHEMA";
+    private static final String TABLE = "MY_TABLE";
+
+    // Default pipe: Snowflake auto-creates this on first channel open
+    private static final String PIPE = TABLE + "-STREAMING";
 
     public static void main(String[] args) {
         try {
@@ -43,9 +49,9 @@ public class StreamingIngestExample {
             // Create Snowflake Streaming Ingest Client using try-with-resources
             try (SnowflakeStreamingIngestClient client = SnowflakeStreamingIngestClientFactory.builder(
                     "MY_CLIENT_" + UUID.randomUUID(),
-                    "MY_DATABASE",
-                    "MY_SCHEMA",
-                    "MY_PIPE")
+                    DATABASE,
+                    SCHEMA,
+                    PIPE)
                     .setProperties(props)
                     .build()) {
 
@@ -58,7 +64,8 @@ public class StreamingIngestExample {
                     System.out.println("Channel opened: " + channel.getChannelName());
                     System.out.println("Ingesting " + MAX_ROWS + " rows...");
 
-                    // Ingest rows
+                    // Ingest rows — column names must match the target table schema.
+                    // The default pipe uses MATCH_BY_COLUMN_NAME to map fields.
                     for (int i = 1; i <= MAX_ROWS; i++) {
                         String rowId = String.valueOf(i);
                         Map<String, Object> row = Map.of(
@@ -68,7 +75,6 @@ public class StreamingIngestExample {
                         );
                         channel.appendRow(row, rowId);
 
-                        // Print progress every 10,000 rows
                         if (i % 10_000 == 0) {
                             System.out.println("Ingested " + i + " rows...");
                         }

--- a/python-example/README.md
+++ b/python-example/README.md
@@ -1,19 +1,32 @@
 # Python Snowpipe Streaming SDK Example
 
-This example demonstrates how to use the Snowflake Streaming Ingest SDK in Python to ingest data into Snowflake in real-time.
+This example demonstrates how to use the Snowflake Streaming Ingest SDK in Python to ingest data into Snowflake in real-time using the [high-performance architecture](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-overview) and default pipe.
 
 ## Prerequisites
 
 - Python 3.9 or higher
 - pip (Python package manager)
 - A Snowflake account with appropriate permissions
-- A Snowflake table to ingest data into
+- RSA key-pair authentication configured
 
 ## Setup
 
-### 1. Create a Snowflake Table
+### 1. Generate RSA Key Pair
 
-Before running the example, create a table in your Snowflake account:
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+Register the public key with your Snowflake user:
+
+```sql
+ALTER USER MY_USER SET RSA_PUBLIC_KEY='<contents of rsa_key.pub, without header/footer>';
+```
+
+### 2. Create a Snowflake Table
+
+Create a target table in your Snowflake account:
 
 ```sql
 CREATE OR REPLACE TABLE MY_DATABASE.MY_SCHEMA.MY_TABLE (
@@ -23,15 +36,7 @@ CREATE OR REPLACE TABLE MY_DATABASE.MY_SCHEMA.MY_TABLE (
 );
 ```
 
-### 2. Create a Snowpipe
-
-Create a Snowpipe for streaming ingestion:
-
-```sql
-CREATE OR REPLACE PIPE MY_DATABASE.MY_SCHEMA.MY_PIPE 
-AS COPY INTO MY_DATABASE.MY_SCHEMA.MY_TABLE 
-FROM @%MY_TABLE;
-```
+No `CREATE PIPE` is needed — the high-performance architecture automatically creates a **default pipe** named `MY_TABLE-STREAMING` when you first open a channel.
 
 ### 3. Install Dependencies
 
@@ -50,27 +55,27 @@ pip install -r requirements.txt
 
 ### 4. Configure Authentication
 
-Create a `profile.json` file in the root of the `python-example` directory with your Snowflake credentials. You can use `profile.json.example` as a template:
+Create a `profile.json` file in the `python-example` directory using `profile.json.example` as a template:
 
 ```json
 {
-  "account": "<account>",
+  "account": "<account_identifier>",
   "user": "your_username",
-  "url": "https://<account>.<locator>.snowflakecomputing.com:443",
-  "private_key": "your_private_key_path_or_content",
+  "url": "https://<account_identifier>.snowflakecomputing.com:443",
+  "private_key_file": "rsa_key.p8",
   "role": "your_role"
 }
 ```
 
-**Note:** For production use, consider using environment variables or a secure credential manager instead of storing credentials in a file.
+**Note:** Use `private_key_file` to reference the key file path. For production, consider using a secure credential manager.
 
 ### 5. Update Configuration
 
-Edit `streaming_ingest_example.py` and update the following values to match your Snowflake setup:
+Edit `streaming_ingest_example.py` and update the constants at the top of the file:
 
-- `MY_DATABASE` - Your database name
-- `MY_SCHEMA` - Your schema name  
-- `MY_PIPE` - Your pipe name
+- `DATABASE` - Your database name
+- `SCHEMA` - Your schema name
+- `TABLE` - Your table name (the pipe name is derived automatically as `<TABLE>-STREAMING`)
 
 ## Run
 
@@ -80,14 +85,14 @@ python streaming_ingest_example.py
 
 ## What the Example Does
 
-1. **Creates a Streaming Ingest Client** - Initializes a connection to Snowflake using the credentials from `profile.json`
-2. **Opens a Channel** - Creates a channel for streaming data into the specified pipe
-3. **Ingests Data** - Sends 100,000 rows of sample data with three columns:
+1. **Creates a Streaming Ingest Client** - Connects to Snowflake using credentials from `profile.json`
+2. **Opens a Channel** - Creates a channel on the default pipe (`MY_TABLE-STREAMING`)
+3. **Ingests Data** - Streams 100,000 rows with columns matched by name (MATCH_BY_COLUMN_NAME):
    - `c1`: Integer counter
    - `c2`: String representation of the counter
    - `ts`: Current timestamp
-4. **Waits for Completion** - Polls the channel status to ensure all data has been committed
-5. **Closes Resources** - Properly closes the channel and client
+4. **Waits for Completion** - Polls the channel status until all data is committed
+5. **Closes Resources** - Properly closes the channel and client via context managers
 
 ## Expected Output
 
@@ -106,29 +111,26 @@ Data ingestion completed
 
 ## Logging
 
-You can adjust the logging level by setting the `SS_LOG_LEVEL` environment variable:
+Adjust the logging level with the `SS_LOG_LEVEL` environment variable:
 
 ```bash
-# For more detailed logs
-export SS_LOG_LEVEL=info
-python streaming_ingest_example.py
-
-# For debug logs
-export SS_LOG_LEVEL=debug
+export SS_LOG_LEVEL=info    # More detailed logs
+export SS_LOG_LEVEL=debug   # Debug logs
 python streaming_ingest_example.py
 ```
 
-The script sets this to `warn` by default to reduce output noise.
+The script defaults to `warn` to reduce output noise.
 
 ## Troubleshooting
 
 - **Connection Issues**: Verify your `profile.json` credentials and network connectivity to Snowflake
-- **Permission Errors**: Ensure your user has the necessary privileges to write to the specified database, schema, and pipe
-- **Table Not Found**: Verify the table exists and the pipe is configured correctly
+- **Permission Errors**: Ensure your role has the necessary privileges on the database, schema, and table
+- **Table Not Found**: Verify the table exists — the default pipe is created automatically
+- **VARIANT Columns**: If using VARIANT columns, pass data as a Python `dict`, not a JSON string
 - **Import Errors**: Make sure you've installed all dependencies with `pip install -r requirements.txt`
 
 ## Additional Resources
 
-- [Snowflake Streaming Ingest SDK Documentation](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-overview)
-- [Snowflake Ingest Python SDK on PyPI](https://pypi.org/project/snowpipe-streaming/)
-
+- [High-Performance Streaming Overview](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-overview)
+- [Getting Started Guide](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-getting-started)
+- [Snowpipe Streaming SDK on PyPI](https://pypi.org/project/snowpipe-streaming/)

--- a/python-example/profile.json.example
+++ b/python-example/profile.json.example
@@ -1,7 +1,7 @@
 {
-  "account": "<account>",
+  "account": "<account_identifier>",
   "user": "your_username",
-  "url": "https://<account>.<locator>.snowflakecomputing.com:443",
-  "private_key": "path_to_private_key.pem"
+  "url": "https://<account_identifier>.snowflakecomputing.com:443",
+  "private_key_file": "rsa_key.p8",
+  "role": "your_role"
 }
-

--- a/python-example/streaming_ingest_example.py
+++ b/python-example/streaming_ingest_example.py
@@ -1,12 +1,10 @@
 """
-Example demonstrating how to use the Snowflake Streaming Ingest SDK in Python.
+Example demonstrating how to use the Snowflake Streaming Ingest SDK in Python
+with the high-performance architecture and default pipe.
 
-This example shows how to:
-1. Create a Snowflake Streaming Ingest Client
-2. Open a channel for data ingestion
-3. Ingest rows of data
-4. Wait for ingestion to complete
-5. Close resources properly
+The default pipe is automatically created by Snowflake when you first
+open a channel. No CREATE PIPE DDL is required. The default pipe name
+follows the convention: <TABLE_NAME>-STREAMING
 """
 
 from datetime import datetime
@@ -24,26 +22,35 @@ MAX_ROWS = 100_000
 POLL_ATTEMPTS = 30
 POLL_INTERVAL_MS = 1000
 
+# Replace these with your Snowflake object names
+DATABASE = "MY_DATABASE"
+SCHEMA = "MY_SCHEMA"
+TABLE = "MY_TABLE"
+
+# Default pipe: Snowflake auto-creates this on first channel open
+PIPE = f"{TABLE}-STREAMING"
+
 
 def main():
     """Main function to demonstrate streaming data ingestion."""
-    
+
     # Create Snowflake Streaming Ingest Client using context manager
     with StreamingIngestClient(
         client_name=f"MY_CLIENT_{uuid.uuid4()}",
-        db_name="MY_DATABASE",
-        schema_name="MY_SCHEMA",
-        pipe_name="MY_PIPE",
+        db_name=DATABASE,
+        schema_name=SCHEMA,
+        pipe_name=PIPE,
         profile_json="profile.json"
     ) as client:
-        
+
         print("Client created successfully")
-        
+
         # Open a channel for data ingestion using context manager
         with client.open_channel(f"MY_CHANNEL_{uuid.uuid4()}")[0] as channel:
             print(f"Channel opened: {channel.channel_name}")
-            
-            # Ingest rows
+
+            # Ingest rows — column names must match the target table schema.
+            # The default pipe uses MATCH_BY_COLUMN_NAME to map fields.
             print(f"Ingesting {MAX_ROWS} rows...")
             for i in range(MAX_ROWS):
                 row_id = str(i)
@@ -55,32 +62,30 @@ def main():
                     },
                     row_id
                 )
-                
-                # Print progress every 10,000 rows
+
                 if (i + 1) % 10_000 == 0:
                     print(f"Ingested {i + 1} rows...")
-            
+
             print("All rows submitted. Waiting for ingestion to complete...")
-            
+
             # Wait for ingestion to complete
             for attempt in range(POLL_ATTEMPTS):
                 latest_offset = channel.get_latest_committed_offset_token()
                 print(f"Latest offset token: {latest_offset}")
-                
+
                 if latest_offset == str(MAX_ROWS - 1):
                     print("All data committed successfully")
                     break
-                
+
                 time.sleep(POLL_INTERVAL_MS / 1000)
             else:
                 raise Exception("Ingestion failed after all attempts")
-        
+
         # Channel automatically closed here
         print("Data ingestion completed")
-    
+
     # Client automatically closed here
 
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- Updates Java and Python examples to use the **default pipe** (`<TABLE_NAME>-STREAMING`) instead of requiring manual `CREATE PIPE` DDL
- Bumps Java SDK from v1.0.1 to v1.3.0
- Updates `profile.json.example` to use `private_key_file` (path) with `role` field, matching current docs
- Adds RSA key-pair setup instructions to both READMEs
- Updates documentation links to point to high-performance architecture pages
- Adds comments explaining MATCH_BY_COLUMN_NAME behavior

## Changes
- `java-example/`: Updated code, README, profile.json.example, pom.xml
- `python-example/`: Updated code, README, profile.json.example

## Test plan
- [ ] Verify Java example compiles with `mvn clean package`
- [ ] Verify Python example runs with latest `snowpipe-streaming` package
- [ ] Confirm default pipe is auto-created on first channel open
- [ ] Review profile.json.example matches [getting started guide](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-getting-started)

🤖 Generated with [Claude Code](https://claude.com/claude-code)