### PR TITLE
Add monitor-abort examples for Python and Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A complete Maven project demonstrating the Snowpipe Streaming SDK in Java. Inclu
 - Full example code with proper error handling
 - Comprehensive setup instructions
 - Sample configuration files
+- **[Monitoring & Abort](./java-example/monitoring)** — Monitor channel status, track offset lag, inject errors, and abort on error increase
 
 ### [Python Example](./python-example)
 A complete Python project demonstrating the Snowpipe Streaming SDK in Python. Includes:
@@ -23,6 +24,7 @@ A complete Python project demonstrating the Snowpipe Streaming SDK in Python. In
 - Clean, well-documented example code
 - Setup instructions with virtual environment
 - Sample configuration files
+- **[Monitoring & Abort](./python-example/monitoring)** — Monitor channel status, track offset lag, inject errors, abort on error increase, and optional live matplotlib plotting
 
 ## Getting Started
 

--- a/java-example/monitoring/.gitignore
+++ b/java-example/monitoring/.gitignore
@@ -1,0 +1,5 @@
+target/
+profile.json
+*.class
+.idea/
+*.iml

--- a/java-example/monitoring/README.md
+++ b/java-example/monitoring/README.md
@@ -1,0 +1,109 @@
+# Snowpipe Streaming: Monitor & Abort Example (Java)
+
+This example demonstrates how to monitor Snowpipe Streaming channel status in real-time and automatically halt production when server-side errors are detected.
+
+## What It Does
+
+- Streams rows using the Snowpipe Streaming Java SDK (high-performance architecture)
+- Polls `getChannelStatus()` during production to track committed offsets, error counts, and processing latency
+- Computes **offset lag** (sent - committed) and prints it to console
+- **Aborts production** when `getRowsErrorCount()` increases — useful for catching schema mismatches early
+- Supports **error injection** via a configurable flag to demonstrate the abort behavior
+- Uses [Java Faker](https://github.com/DiUS/java-faker) for realistic test data
+
+> **Note:** The Python version of this example includes live matplotlib plotting of offset lag. This Java version uses console output only.
+
+## Prerequisites
+
+- Java 11+
+- Maven 3.6+
+- A Snowflake account with the [high-performance architecture](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-overview) enabled
+- RSA key-pair authentication configured (see [parent README](../README.md))
+
+## Setup
+
+1. Create the target table in Snowflake:
+
+```sql
+CREATE OR REPLACE TABLE MY_DATABASE.MY_SCHEMA.MY_TABLE (
+    user_id INTEGER,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100),
+    email VARCHAR(255),
+    phone_number VARCHAR(50),
+    address VARCHAR(500),
+    date_of_birth DATE,
+    registration_date TIMESTAMP_NTZ,
+    city VARCHAR(100),
+    state VARCHAR(100),
+    country VARCHAR(100),
+    ingestion_time TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+);
+```
+
+> No `CREATE PIPE` is needed — the default pipe `MY_TABLE-STREAMING` is auto-created.
+
+2. Copy `profile.json.example` to `profile.json` and fill in your credentials:
+
+```bash
+cp profile.json.example profile.json
+```
+
+3. Build the project:
+
+```bash
+mvn clean package
+```
+
+## Configuration
+
+Edit the constants at the top of `MonitorAbortExample.java`:
+
+| Constant | Default | Description |
+|----------|---------|-------------|
+| `TOTAL_ROWS` | `500` | Number of rows to stream |
+| `SEND_INTERVAL_MS` | `100` | Delay between row appends (ms) |
+| `POLL_INTERVAL_MS` | `500` | How often to poll channel status (ms) |
+| `TEST_ERROR_OFFSET` | `-1` | Set to a positive integer to inject a schema error at that offset. `-1` disables error injection |
+
+## Running
+
+### Demo 1: Normal monitoring (no errors)
+
+```bash
+mvn exec:java
+```
+
+With `TEST_ERROR_OFFSET = -1`, all 500 rows stream successfully. The monitor prints status updates showing lag converging to zero.
+
+### Demo 2: Error injection with abort
+
+Set `TEST_ERROR_OFFSET = 200` (or any positive integer) in `MonitorAbortExample.java`, rebuild, then run:
+
+```bash
+mvn clean package
+mvn exec:java
+```
+
+At offset 200, a row with invalid types is injected. When the monitor detects `getRowsErrorCount()` increasing, it halts production immediately.
+
+## Monitor Output
+
+Each status poll prints:
+
+```
+[monitor] committed= 150
+[monitor] rows_inserted= 150
+[monitor] rows_error_count= 0
+[monitor] server_avg_processing_latency= 245
+[monitor] last_error_offset_token_upper_bound= null
+[monitor] last_error_message= null
+[monitor] offset_lag= 50
+```
+
+## SSv2 API Notes
+
+This example uses the **high-performance architecture** (SSv2) API:
+
+- `appendRow(row, offsetToken)` — fire-and-forget, validation is server-side
+- `getChannelStatus()` — returns `ChannelStatus` with `getRowsErrorCount()`, `getRowsInsertedCount()`, `getLatestOffsetToken()`, `getServerAvgProcessingLatency()`, `getLastErrorMessage()`, etc.

--- a/java-example/monitoring/pom.xml
+++ b/java-example/monitoring/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.snowflake.example</groupId>
+    <artifactId>snowpipe-streaming-monitoring-example</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Snowflake Snowpipe Streaming SDK -->
+        <!-- See https://repo1.maven.org/maven2/com/snowflake/snowpipe-streaming/ for latest versions -->
+        <dependency>
+            <groupId>com.snowflake</groupId>
+            <artifactId>snowpipe-streaming</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+
+        <!-- Jackson for JSON processing (profile.json) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+
+        <!-- Java Faker for realistic data generation -->
+        <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+
+        <!-- SLF4J for logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.snowflake.example.monitoring.MonitorAbortExample</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java-example/monitoring/profile.json.example
+++ b/java-example/monitoring/profile.json.example
@@ -1,0 +1,7 @@
+{
+  "account": "<account_identifier>",
+  "user": "your_username",
+  "url": "https://<account_identifier>.snowflakecomputing.com:443",
+  "private_key_file": "rsa_key.p8",
+  "role": "your_role"
+}

--- a/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/FakeDataGenerator.java
+++ b/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/FakeDataGenerator.java
@@ -1,0 +1,38 @@
+package com.snowflake.example.monitoring;
+
+import com.github.javafaker.Faker;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Generates fake user data rows using Java Faker.
+ * Produces the same schema as the Python monitor_abort_example.
+ */
+public class FakeDataGenerator {
+    private final Faker faker = new Faker();
+
+    public Map<String, Object> makeRow(int userId) {
+        Map<String, Object> row = new HashMap<>();
+        row.put("user_id", userId);
+        row.put("first_name", faker.name().firstName());
+        row.put("last_name", faker.name().lastName());
+        row.put("email", faker.internet().emailAddress());
+        row.put("phone_number", faker.phoneNumber().phoneNumber());
+        row.put("address", faker.address().fullAddress());
+        row.put("date_of_birth", randomDateOfBirth().toString());
+        row.put("registration_date", LocalDateTime.now().toString());
+        row.put("city", faker.address().city());
+        row.put("state", faker.address().state());
+        row.put("country", faker.address().country());
+        return row;
+    }
+
+    private LocalDate randomDateOfBirth() {
+        java.util.Date dob = faker.date().birthday(18, 80);
+        return dob.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+}

--- a/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/FakeDataGenerator.java
+++ b/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/FakeDataGenerator.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Generates fake user data rows using Java Faker.
@@ -24,7 +25,8 @@ public class FakeDataGenerator {
         row.put("phone_number", faker.phoneNumber().phoneNumber());
         row.put("address", faker.address().fullAddress());
         row.put("date_of_birth", randomDateOfBirth().toString());
-        row.put("registration_date", LocalDateTime.now().toString());
+        row.put("registration_date", faker.date().past(90, TimeUnit.DAYS)
+                .toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime().toString());
         row.put("city", faker.address().city());
         row.put("state", faker.address().state());
         row.put("country", faker.address().country());

--- a/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/MonitorAbortExample.java
+++ b/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/MonitorAbortExample.java
@@ -1,0 +1,212 @@
+package com.snowflake.example.monitoring;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snowflake.ingest.streaming.ChannelStatus;
+import com.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Properties;
+import java.util.UUID;
+
+/**
+ * Demonstrates monitoring Snowpipe Streaming channel status in real-time
+ * and automatically halting production when server-side errors are detected.
+ *
+ * <p>This example mirrors the Python monitor_abort_example.py and uses the
+ * SSv2 high-performance architecture API:
+ * <ul>
+ *   <li>{@code appendRow()} - fire-and-forget row append (server-side validation)</li>
+ *   <li>{@code getChannelStatus()} - rich status with error counts, latency, committed offset</li>
+ * </ul>
+ *
+ * <p>Configuration flags at the top of this class control behavior:
+ * <ul>
+ *   <li>{@code TEST_ERROR_OFFSET = -1} disables error injection</li>
+ *   <li>{@code TEST_ERROR_OFFSET = 200} injects a schema error at offset 200 to trigger abort</li>
+ * </ul>
+ */
+public class MonitorAbortExample {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String PROFILE_PATH = "profile.json";
+
+    // Snowflake configuration
+    private static final String DATABASE = "MY_DATABASE";
+    private static final String SCHEMA = "MY_SCHEMA";
+    private static final String TABLE = "MY_TABLE";
+    private static final String PIPE = TABLE + "-STREAMING";
+    private static final String CHANNEL_NAME = "monitor_abort_channel";
+
+    // Tuning knobs
+    private static final int TOTAL_ROWS = 500;
+    private static final int SEND_INTERVAL_MS = 100;
+    private static final int POLL_INTERVAL_MS = 500;
+    private static final int TEST_ERROR_OFFSET = -1; // -1 to disable error injection
+
+    public static void main(String[] args) {
+        try {
+            // Load properties from profile.json
+            Properties props = new Properties();
+            JsonNode jsonNode = MAPPER.readTree(Files.readAllBytes(Paths.get(PROFILE_PATH)));
+            jsonNode.fields().forEachRemaining(entry ->
+                    props.put(entry.getKey(), entry.getValue().asText()));
+
+            try (SnowflakeStreamingIngestClient client = SnowflakeStreamingIngestClientFactory.builder(
+                    "MY_CLIENT_" + UUID.randomUUID(),
+                    DATABASE,
+                    SCHEMA,
+                    PIPE)
+                    .setProperties(props)
+                    .build()) {
+
+                System.out.println("Client created successfully");
+
+                // Open a channel
+                SnowflakeStreamingIngestChannel channel =
+                        client.openChannel(CHANNEL_NAME, "0").getChannel();
+                System.out.println("Channel opened: " + channel.getChannelName());
+
+                // If channel already has committed state, drop and reopen for a fresh run
+                ChannelStatus initialStatus = channel.getChannelStatus();
+                if (initialStatus.getLatestOffsetToken() != null) {
+                    System.out.println("Existing channel state detected; dropping and reopening...");
+                    channel.close();
+                    client.dropChannel(CHANNEL_NAME);
+                    Thread.sleep(500);
+                    channel = client.openChannel(CHANNEL_NAME, "0").getChannel();
+                    System.out.println("Reopened channel: " + channel.getChannelName());
+                    Thread.sleep(500);
+                }
+
+                FakeDataGenerator generator = new FakeDataGenerator();
+                OffsetTracker tracker = new OffsetTracker();
+                long lastPollTime = 0;
+                long previousErrorCount = 0;
+                boolean firstPoll = true;
+
+                // ---- Producer loop ----
+                for (int i = 1; i <= TOTAL_ROWS; i++) {
+                    Map<String, Object> row = generator.makeRow(i);
+
+                    // Error injection
+                    if (i == TEST_ERROR_OFFSET) {
+                        row.put("user_id", "BAD_ID");             // should be INTEGER
+                        row.put("date_of_birth", "INVALID_DATE"); // should be DATE
+                        row.put("registration_date", "INVALID_TS"); // should be TIMESTAMP_NTZ
+                        System.out.println("[producer] Injecting schema error at offset=" + i);
+                    }
+
+                    channel.appendRow(row, String.valueOf(i));
+                    tracker.updateSent(i);
+
+                    if (i % 10 == 0) {
+                        System.out.println("[producer] sent offset=" + i);
+                    }
+
+                    // ---- Monitor loop ----
+                    long now = System.currentTimeMillis();
+                    if (now - lastPollTime >= POLL_INTERVAL_MS) {
+                        ChannelStatus status = channel.getChannelStatus();
+                        boolean shouldAbort = monitorChannelStatus(
+                                status, tracker, previousErrorCount, firstPoll);
+
+                        long currentErrorCount = status.getRowsErrorCount();
+                        if (shouldAbort) {
+                            break;
+                        }
+                        previousErrorCount = currentErrorCount;
+                        firstPoll = false;
+                        lastPollTime = now;
+                    }
+
+                    Thread.sleep(SEND_INTERVAL_MS);
+                }
+
+                // Wait for commits to catch up
+                System.out.println("Waiting for commits to catch up to " + tracker.getSentHighestOffset());
+                int maxAttempts = 30;
+                for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+                    ChannelStatus status = channel.getChannelStatus();
+                    String latestOffset = status.getLatestOffsetToken();
+                    System.out.println("Latest committed offset: " + latestOffset);
+
+                    try {
+                        if (latestOffset != null
+                                && Long.parseLong(latestOffset) >= tracker.getSentHighestOffset()) {
+                            System.out.println("All data committed successfully.");
+                            break;
+                        }
+                    } catch (NumberFormatException e) {
+                        System.out.println("Warning: unexpected offset token format: " + latestOffset);
+                    }
+                    if (attempt == maxAttempts) {
+                        System.out.println("Warning: Timed out waiting for commits.");
+                    }
+                    Thread.sleep(1000);
+                }
+
+                System.out.println("Final committed: "
+                        + channel.getChannelStatus().getLatestOffsetToken());
+
+                channel.close();
+                // Drop channel for demo cleanup. In production, you typically reopen
+                // existing channels to resume from the last committed offset.
+                client.dropChannel(CHANNEL_NAME);
+
+            } // client auto-closed
+
+            System.out.println("Monitor-abort demo completed.");
+
+        } catch (IOException | InterruptedException e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Log channel status, compute lag, and detect error-count increases.
+     * Returns true if production should be aborted.
+     */
+    private static boolean monitorChannelStatus(
+            ChannelStatus status,
+            OffsetTracker tracker,
+            long previousErrorCount,
+            boolean firstPoll) {
+
+        String committedToken = status.getLatestOffsetToken();
+        OptionalLong lag = tracker.computeLag(committedToken);
+
+        System.out.println();
+        System.out.println("[monitor] committed= " + committedToken);
+        System.out.println("[monitor] rows_inserted= " + status.getRowsInsertedCount());
+        System.out.println("[monitor] rows_error_count= " + status.getRowsErrorCount());
+        System.out.println("[monitor] server_avg_processing_latency= "
+                + status.getServerAvgProcessingLatency());
+        System.out.println("[monitor] last_error_offset_token_upper_bound= "
+                + status.getLastErrorOffsetTokenUpperBound());
+        System.out.println("[monitor] last_error_message= " + status.getLastErrorMessage());
+        System.out.println("[monitor] offset_lag= " + (lag.isPresent() ? lag.getAsLong() : "N/A"));
+        System.out.println();
+
+        if (firstPoll) {
+            return false;
+        }
+
+        long currentErrorCount = status.getRowsErrorCount();
+        if (currentErrorCount > previousErrorCount) {
+            System.out.println("[monitor] Error count increased (" + previousErrorCount
+                    + " -> " + currentErrorCount + ") - halting production.");
+            System.out.println("Monitor requested to halt production - current offset not yet sent= "
+                    + (tracker.getSentHighestOffset() + 1));
+            return true;
+        }
+        return false;
+    }
+}

--- a/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/OffsetTracker.java
+++ b/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/OffsetTracker.java
@@ -1,0 +1,37 @@
+package com.snowflake.example.monitoring;
+
+import java.util.OptionalLong;
+
+/**
+ * Tracks the highest sent offset and computes lag against the
+ * server-side committed offset.
+ */
+public class OffsetTracker {
+    private long sentHighestOffset = 0;
+
+    public void updateSent(long offset) {
+        if (offset > sentHighestOffset) {
+            sentHighestOffset = offset;
+        }
+    }
+
+    public long getSentHighestOffset() {
+        return sentHighestOffset;
+    }
+
+    /**
+     * Compute lag = sentHighestOffset - committed.
+     * Returns empty if committedToken is null or unparseable.
+     */
+    public OptionalLong computeLag(String committedToken) {
+        if (committedToken == null) {
+            return OptionalLong.empty();
+        }
+        try {
+            long committed = Long.parseLong(committedToken);
+            return OptionalLong.of(sentHighestOffset - committed);
+        } catch (NumberFormatException e) {
+            return OptionalLong.empty();
+        }
+    }
+}

--- a/python-example/monitoring/README.md
+++ b/python-example/monitoring/README.md
@@ -1,0 +1,100 @@
+# Snowpipe Streaming: Monitor & Abort Example (Python)
+
+This example demonstrates how to monitor Snowpipe Streaming channel status in real-time and automatically halt production when server-side errors are detected.
+
+## What It Does
+
+- Streams rows using the Snowpipe Streaming Python SDK (high-performance architecture)
+- Polls `get_channel_status()` during production to track committed offsets, error counts, and processing latency
+- Computes **offset lag** (sent - committed) and optionally plots it live with matplotlib
+- **Aborts production** when `rows_error_count` increases — useful for catching schema mismatches early
+- Supports **error injection** via a configurable flag to demonstrate the abort behavior
+
+## Prerequisites
+
+- Python 3.9+
+- A Snowflake account with the [high-performance architecture](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-overview) enabled
+- RSA key-pair authentication configured (see [parent README](../README.md))
+
+## Setup
+
+1. Create the target table in Snowflake:
+
+```sql
+CREATE OR REPLACE TABLE MY_DATABASE.MY_SCHEMA.MY_TABLE (
+    user_id INTEGER,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100),
+    email VARCHAR(255),
+    phone_number VARCHAR(50),
+    address VARCHAR(500),
+    date_of_birth DATE,
+    registration_date TIMESTAMP_NTZ,
+    city VARCHAR(100),
+    state VARCHAR(100),
+    country VARCHAR(100),
+    ingestion_time TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+);
+```
+
+> No `CREATE PIPE` is needed — the default pipe `MY_TABLE-STREAMING` is auto-created.
+
+2. Copy `profile.json.example` to `profile.json` and fill in your credentials:
+
+```bash
+cp profile.json.example profile.json
+```
+
+3. Install dependencies:
+
+```bash
+python -m venv venv
+source venv/bin/activate  # or venv\Scripts\activate on Windows
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Edit the constants at the top of `monitor_abort_example.py`:
+
+| Constant | Default | Description |
+|----------|---------|-------------|
+| `TOTAL_ROWS` | `500` | Number of rows to stream |
+| `SEND_INTERVAL_MS` | `100` | Delay between row appends (ms) |
+| `POLL_MS` | `500` | How often to poll channel status (ms) |
+| `TEST_ERROR_OFFSET` | `-1` | Set to a positive integer to inject a schema error at that offset. `-1` disables error injection |
+| `ENABLE_PLOTTING` | `False` | Set to `True` for live matplotlib lag plot (falls back gracefully if matplotlib is not installed) |
+
+## Running
+
+### Demo 1: Normal monitoring (no errors)
+
+```bash
+python monitor_abort_example.py
+```
+
+With `TEST_ERROR_OFFSET = -1`, all 500 rows stream successfully. The monitor prints status updates and the live plot shows offset lag converging to zero.
+
+### Demo 2: Error injection with abort
+
+Set `TEST_ERROR_OFFSET = 200` (or any positive integer) in the script, then run:
+
+```bash
+python monitor_abort_example.py
+```
+
+At offset 200, a row with invalid types is injected. When the monitor detects `rows_error_count` increasing, it halts production immediately.
+
+## Monitor Output
+
+Each status poll prints:
+
+```
+[monitor] committed= 150
+[monitor] rows_inserted= 150
+[monitor] rows_error_count= 0
+[monitor] server_avg_processing_latency= 245
+[monitor] last_error_offset_token_upper_bound= None
+[monitor] last_error_message= None
+[monitor] offset_lag= 50
+```

--- a/python-example/monitoring/monitor_abort_example.py
+++ b/python-example/monitoring/monitor_abort_example.py
@@ -189,7 +189,10 @@ def main(total_rows: int = TOTAL_ROWS, send_interval_ms: int = SEND_INTERVAL_MS,
     print(f"Waiting for commits to catch up to last sent... {tracker.sent_highest_offset}")
 
     def token_reached(latest_token):
-        return latest_token is not None and int(latest_token) >= tracker.sent_highest_offset
+        try:
+            return latest_token is not None and int(latest_token) >= tracker.sent_highest_offset
+        except (TypeError, ValueError):
+            return False
 
     channel.wait_for_commit(token_reached, timeout_seconds=15)
 

--- a/python-example/monitoring/monitor_abort_example.py
+++ b/python-example/monitoring/monitor_abort_example.py
@@ -1,0 +1,210 @@
+import time
+import os
+from typing import Optional
+from faker import Faker
+
+try:
+    import matplotlib.pyplot as plt
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+
+# Must be set before importing StreamingIngestClient
+os.environ["SS_LOG_LEVEL"] = "warn"
+os.environ["SS_ENABLE_METRICS"] = "true"
+from snowflake.ingest.streaming import StreamingIngestClient
+
+# Configuration
+DATABASE = "MY_DATABASE"
+SCHEMA = "MY_SCHEMA"
+PIPE = "MY_TABLE-STREAMING"
+PROFILE_JSON_PATH = "profile.json"
+CHANNEL_NAME = "monitor_abort_channel"
+ENABLE_PLOTTING = False  # Set to True for live matplotlib lag chart
+
+TOTAL_ROWS = 500
+SEND_INTERVAL_MS = 100
+POLL_MS = 500
+TEST_ERROR_OFFSET = -1  # -1 to disable test error injection
+
+
+fake = Faker()
+
+def make_row(i: int) -> dict:
+    return {
+        "user_id": i,
+        "first_name": fake.first_name(),
+        "last_name": fake.last_name(),
+        "email": fake.email(),
+        "phone_number": fake.phone_number(),
+        "address": fake.address().replace("\n", ", "),
+        "date_of_birth": fake.date_of_birth(minimum_age=18, maximum_age=80).isoformat(),
+        "registration_date": fake.date_time_this_year().isoformat(),
+        "city": fake.city(),
+        "state": fake.state(),
+        "country": fake.country(),
+    }
+
+class OffsetTracker:
+    def __init__(self) -> None:
+        self.sent_highest_offset: int = 0
+
+    def update_sent(self, offset: int) -> None:
+        if offset > self.sent_highest_offset:
+            self.sent_highest_offset = offset
+
+    def compute_lag(self, committed_token: Optional[str]) -> Optional[int]:
+        try:
+            committed = None if committed_token is None else int(committed_token)
+        except (TypeError, ValueError):
+            return None
+        if committed is None:
+            return None
+        return self.sent_highest_offset - committed
+
+class LagPlotter:
+    def __init__(self, enabled: bool):
+        self.enabled = enabled and MATPLOTLIB_AVAILABLE
+        self.fig = None
+        self.ax = None
+        self.line = None
+        self.x_data = []
+        self.y_data = []
+
+    def setup(self) -> None:
+        if not self.enabled:
+            return
+        plt.ion()
+        self.fig, self.ax = plt.subplots()
+        self.ax.set_title("Offset Lag (sent - committed)")
+        self.ax.set_xlabel("Sent offset")
+        self.ax.set_ylabel("Lag")
+        (self.line,) = self.ax.plot([], [], label="lag")
+        self.ax.legend(loc="upper right")
+
+    def add_point(self, x_value: int, y_value: int) -> None:
+        if not self.enabled or self.line is None:
+            return
+        self.x_data.append(x_value)
+        self.y_data.append(y_value)
+        self.line.set_data(self.x_data, self.y_data)
+        self.ax.relim()
+        self.ax.autoscale_view()
+        plt.pause(0.001)
+
+    def finalize(self) -> None:
+        if not self.enabled:
+            return
+        plt.ioff()
+        plt.show()
+
+def monitor_channel_status(status, tracker: OffsetTracker, plotter: LagPlotter, error_count_prev: Optional[int]) -> tuple[Optional[int], bool]:
+    """Log channel status, update plot, and detect error-count increase.
+    Returns (new_error_count_prev, abort_requested).
+    """
+    committed_token = status.latest_committed_offset_token
+    lag = tracker.compute_lag(committed_token)
+
+    print()
+    print("[monitor] committed=", committed_token)
+    print("[monitor] rows_inserted=", status.rows_inserted_count)
+    print("[monitor] rows_error_count=", status.rows_error_count)
+    print("[monitor] server_avg_processing_latency=", status.server_avg_processing_latency)
+    print("[monitor] last_error_offset_token_upper_bound=", status.last_error_offset_token_upper_bound)
+    print("[monitor] last_error_message=", status.last_error_message)
+    if lag is not None:
+        print("[monitor] offset_lag=", lag)
+    else:
+        print("[monitor] offset_lag=", "N/A")
+    print()
+
+    if lag is not None:
+        plotter.add_point(tracker.sent_highest_offset, lag)
+
+    current_error_count = status.rows_error_count
+    if error_count_prev is None:
+        return current_error_count, False
+    if current_error_count > error_count_prev:
+        print("[monitor] Error count increased (", error_count_prev, "->", current_error_count, ") - halting production.")
+        print("Monitor requested to halt production - current offset not yet sent=", tracker.sent_highest_offset + 1)
+        return current_error_count, True
+    return current_error_count, False
+
+def main(total_rows: int = TOTAL_ROWS, send_interval_ms: int = SEND_INTERVAL_MS, poll_ms: int = POLL_MS) -> None:
+    client = StreamingIngestClient(
+        "MY_CLIENT",
+        DATABASE,
+        SCHEMA,
+        PIPE,
+        profile_json=PROFILE_JSON_PATH,
+        properties=None,
+    )
+
+    channel, status = client.open_channel(CHANNEL_NAME)
+    print("Channel:", status.channel_name, "status:", status.status_code)
+
+    # If channel already has committed state, drop and reopen for a fresh run
+    initial_status = channel.get_channel_status()
+    if initial_status.latest_committed_offset_token is not None:
+        print("Existing channel state detected; dropping and reopening for a fresh run...")
+        channel.close(drop=True)
+        time.sleep(0.5)
+        channel, status = client.open_channel(CHANNEL_NAME)
+        print("Reopened channel:", status.channel_name, "status:", status.status_code)
+        time.sleep(0.5)
+
+    plotter = LagPlotter(ENABLE_PLOTTING)
+    plotter.setup()
+
+    tracker = OffsetTracker()
+    last_poll_time = 0.0
+    error_count_prev: Optional[int] = None
+
+    # Producer loop
+    for i in range(1, total_rows + 1):
+        row = make_row(i)
+        # If TEST_ERROR_OFFSET is set, inject a deliberate schema error for exactly one row
+        if i == TEST_ERROR_OFFSET:
+            row["user_id"] = "BAD_ID"           # should be INTEGER
+            row["date_of_birth"] = "INVALID_DATE"  # should be DATE
+            row["registration_date"] = "INVALID_TS"  # should be TIMESTAMP_NTZ
+            print("[producer] Injecting schema error at offset=", i)
+        channel.append_row(row, offset_token=str(i))
+        tracker.update_sent(i)
+        if i % 10 == 0:
+            print(f"[producer] sent offset={i}")
+
+        # Monitor loop
+        now = time.time()
+        if now - last_poll_time >= (poll_ms / 1000):
+            status = channel.get_channel_status()
+            error_count_prev, abort = monitor_channel_status(status, tracker, plotter, error_count_prev)
+            if abort:
+                break
+            last_poll_time = now
+
+        time.sleep(send_interval_ms / 1000)
+
+    # Wait for commits to catch up
+    print(f"Waiting for commits to catch up to last sent... {tracker.sent_highest_offset}")
+
+    def token_reached(latest_token):
+        return latest_token is not None and int(latest_token) >= tracker.sent_highest_offset
+
+    channel.wait_for_commit(token_reached, timeout_seconds=15)
+
+    print("Commits caught up to last sent.")
+    print("Final committed:", channel.get_latest_committed_offset_token())
+
+    channel.close()
+    # Drop channel for demo cleanup. In production, you typically reopen
+    # existing channels to resume from the last committed offset.
+    client.drop_channel(CHANNEL_NAME)
+
+    client.close()
+    plotter.finalize()
+    print("Monitor-abort demo completed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/python-example/monitoring/profile.json.example
+++ b/python-example/monitoring/profile.json.example
@@ -1,0 +1,7 @@
+{
+  "account": "<account_identifier>",
+  "user": "your_username",
+  "url": "https://<account_identifier>.snowflakecomputing.com:443",
+  "private_key_file": "rsa_key.p8",
+  "role": "your_role"
+}

--- a/python-example/monitoring/requirements.txt
+++ b/python-example/monitoring/requirements.txt
@@ -1,0 +1,3 @@
+snowpipe-streaming
+faker>=18.0.0
+matplotlib>=3.7.0   # Optional: for live lag plotting (example runs without it)


### PR DESCRIPTION
## Summary

Adds monitoring & abort examples for both Python and Java that demonstrate real-time channel status tracking with the SSv2 high-performance architecture. These accompany the [YouTube demo](https://www.youtube.com/watch?v=_RJtGrgGGU0).

- **`python-example/monitoring/`** — Polls `get_channel_status()` during production, tracks offset lag (with optional matplotlib live plotting), and aborts when `rows_error_count` increases. Configurable error injection via `TEST_ERROR_OFFSET` flag.
- **`java-example/monitoring/`** — Mirrors the Python pattern using `getChannelStatus()` and `appendRow()`. Console-only output (no plotting). Uses Java Faker for realistic test data.

Both examples:
- Use the SSv2 `appendRow` / `getChannelStatus` API (server-side validation)
- Support toggling error injection to demo the abort behavior
- Include README with table DDL, configuration reference, and setup instructions
- Were tested end-to-end against Snowflake (500 rows, committed to offset 500, 0 errors)

## Files added

| Directory | Files |
|-----------|-------|
| `python-example/monitoring/` | `monitor_abort_example.py`, `requirements.txt`, `profile.json.example`, `README.md` |
| `java-example/monitoring/` | `MonitorAbortExample.java`, `OffsetTracker.java`, `FakeDataGenerator.java`, `pom.xml`, `.gitignore`, `profile.json.example`, `README.md` |
| Root | Updated `README.md` with links to monitoring examples |

## Test plan

- [x] Python: Ran end-to-end against Snowflake — 500 rows, all committed, 0 errors
- [x] Java: `mvn clean compile` passes, ran end-to-end against Snowflake — 500 rows, all committed, 0 errors
- [x] Python syntax validated via `ast.parse`
- [x] No private data in any committed files (profile.json.example has placeholders only)
- [ ] Verify error injection path (set `TEST_ERROR_OFFSET = 200`, confirm abort triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)