### PR TITLE
Add Node.js Snowpipe Streaming SDK example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,16 @@ A complete Python project demonstrating the Snowpipe Streaming SDK in Python. In
 - Sample configuration files
 - **[Monitoring & Abort](./python-example/monitoring)** — Monitor channel status, track offset lag, inject errors, abort on error increase, and optional live matplotlib plotting
 
+### [Node.js Example](./nodejs-example)
+A complete Node.js project demonstrating the Snowpipe Streaming SDK in Node.js. Includes:
+- npm package configuration with all required dependencies
+- Clean, well-documented example code
+- Setup instructions
+- Sample configuration files
+
 ## Getting Started
 
-1. Choose your preferred language (Java or Python)
+1. Choose your preferred language (Java, Python, or Node.js)
 2. Navigate to the respective example directory
 3. Follow the README instructions in that directory to:
    - Set up your Snowflake table and pipe

--- a/nodejs-example/README.md
+++ b/nodejs-example/README.md
@@ -88,7 +88,7 @@ node streaming_ingest_example.js
    - `c1`: Integer counter
    - `c2`: String representation of the counter
    - `ts`: Current timestamp
-4. **Waits for Completion** - Uses `waitForCommit` to block until all data is committed, then prints the channel status
+4. **Waits for Completion** - Uses `waitForCommit()` to block until all rows are committed, then calls `getChannelStatus()` to display committed offset, rows inserted, error count, and server latency
 5. **Closes Resources** - Properly closes the channel and client via try/finally blocks
 
 ## Expected Output
@@ -100,9 +100,12 @@ Ingesting 100000 rows...
 Ingested 10000 rows...
 Ingested 20000 rows...
 ...
-All rows submitted. Waiting for ingestion to complete...
-Latest committed offset token: 100000
-All data committed successfully
+All rows submitted. Waiting for commit...
+All data committed. Channel status:
+  Committed offset:   100000
+  Rows inserted:      100000
+  Rows errored:       0
+  Avg server latency: 1234 ms
 Data ingestion completed
 ```
 

--- a/nodejs-example/README.md
+++ b/nodejs-example/README.md
@@ -1,0 +1,121 @@
+# Node.js Snowpipe Streaming SDK Example
+
+This example demonstrates how to use the Snowflake Streaming Ingest SDK in Node.js to ingest data into Snowflake in real-time using the [high-performance architecture](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-overview) and default pipe.
+
+## Prerequisites
+
+- Node.js 20 or higher
+- npm (Node.js package manager)
+- A Snowflake account with appropriate permissions
+- RSA key-pair authentication configured
+
+## Setup
+
+### 1. Generate RSA Key Pair
+
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+Register the public key with your Snowflake user:
+
+```sql
+ALTER USER MY_USER SET RSA_PUBLIC_KEY='<contents of rsa_key.pub, without header/footer>';
+```
+
+### 2. Create a Snowflake Table
+
+Create a target table in your Snowflake account:
+
+```sql
+CREATE OR REPLACE TABLE MY_DATABASE.MY_SCHEMA.MY_TABLE (
+    c1 NUMBER,
+    c2 VARCHAR,
+    ts TIMESTAMP_NTZ
+);
+```
+
+No `CREATE PIPE` is needed — the high-performance architecture automatically creates a **default pipe** named `MY_TABLE-STREAMING` when you first open a channel.
+
+### 3. Install Dependencies
+
+```bash
+npm install
+```
+
+### 4. Configure Authentication
+
+Create a `profile.json` file in the `nodejs-example` directory using `profile.json.example` as a template:
+
+```json
+{
+  "account": "<account_identifier>",
+  "user": "your_username",
+  "url": "https://<account_identifier>.snowflakecomputing.com:443",
+  "private_key_file": "rsa_key.p8",
+  "role": "your_role"
+}
+```
+
+**Note:** Use `private_key_file` to reference the key file path. For production, consider using a secure credential manager.
+
+### 5. Update Configuration
+
+Edit `streaming_ingest_example.js` and update the constants at the top of the file:
+
+- `DATABASE` - Your database name
+- `SCHEMA` - Your schema name
+- `TABLE` - Your table name (the pipe name is derived automatically as `<TABLE>-STREAMING`)
+
+## Run
+
+```bash
+npm start
+```
+
+Or directly:
+
+```bash
+node streaming_ingest_example.js
+```
+
+## What the Example Does
+
+1. **Creates a Streaming Ingest Client** - Connects to Snowflake using credentials from `profile.json`
+2. **Opens a Channel** - Creates a channel on the default pipe (`MY_TABLE-STREAMING`)
+3. **Ingests Data** - Streams 100,000 rows with columns matched by name (MATCH_BY_COLUMN_NAME):
+   - `c1`: Integer counter
+   - `c2`: String representation of the counter
+   - `ts`: Current timestamp
+4. **Waits for Completion** - Uses `waitForCommit` to block until all data is committed, then prints the channel status
+5. **Closes Resources** - Properly closes the channel and client via try/finally blocks
+
+## Expected Output
+
+```
+Client created successfully
+Channel opened: MY_CHANNEL_<uuid>
+Ingesting 100000 rows...
+Ingested 10000 rows...
+Ingested 20000 rows...
+...
+All rows submitted. Waiting for ingestion to complete...
+Latest committed offset token: 100000
+All data committed successfully
+Data ingestion completed
+```
+
+## Troubleshooting
+
+- **Connection Issues**: Verify your `profile.json` credentials and network connectivity to Snowflake
+- **Permission Errors**: Ensure your role has the necessary privileges on the database, schema, and table
+- **Table Not Found**: Verify the table exists — the default pipe is created automatically
+- **VARIANT Columns**: If using VARIANT columns, pass data as a plain JavaScript object, not a JSON string
+- **Node.js Version**: Ensure you are running Node.js 20 or higher (`node --version`)
+
+## Additional Resources
+
+- [High-Performance Streaming Overview](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-overview)
+- [Getting Started Guide](https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-getting-started)
+- [Snowpipe Streaming SDK on npm](https://www.npmjs.com/package/snowpipe-streaming)

--- a/nodejs-example/package.json
+++ b/nodejs-example/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "snowpipe-streaming-nodejs-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Snowpipe Streaming SDK example for Node.js",
+  "main": "streaming_ingest_example.js",
+  "scripts": {
+    "start": "node streaming_ingest_example.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "snowpipe-streaming": "^0.1.0"
+  }
+}

--- a/nodejs-example/package.json
+++ b/nodejs-example/package.json
@@ -11,6 +11,6 @@
     "node": ">=20"
   },
   "dependencies": {
-    "snowpipe-streaming": "^0.1.0"
+    "snowpipe-streaming": "^1.4.0"
   }
 }

--- a/nodejs-example/profile.json.example
+++ b/nodejs-example/profile.json.example
@@ -1,0 +1,7 @@
+{
+  "account": "<account_identifier>",
+  "user": "your_username",
+  "url": "https://<account_identifier>.snowflakecomputing.com:443",
+  "private_key_file": "rsa_key.p8",
+  "role": "your_role"
+}

--- a/nodejs-example/streaming_ingest_example.js
+++ b/nodejs-example/streaming_ingest_example.js
@@ -63,21 +63,26 @@ async function main() {
         }
       }
 
-      console.log("All rows submitted. Waiting for ingestion to complete...");
+      console.log("All rows submitted. Waiting for commit...");
 
-      // Wait for all rows to be committed
-      const expectedToken = String(MAX_ROWS);
+      // Wait for all rows to be committed using waitForCommit.
+      // The predicate receives the latest committed offset token
+      // (string or null) and should return true when satisfied.
       await channel.waitForCommit(
-        (token) => token !== null && token === expectedToken,
-        { timeoutMs: 60_000 },
+        (token) => token !== null && Number(token) >= MAX_ROWS,
+        { timeoutMs: 30_000 },
       );
 
-      // Verify channel status
+      // Now that data has landed, check the channel status
       const status = await channel.getChannelStatus();
-      console.log(
-        `Latest committed offset token: ${status.latestCommittedOffsetToken}`,
-      );
-      console.log("All data committed successfully");
+      console.log("All data committed. Channel status:");
+      console.log(`  Committed offset:   ${status.latestCommittedOffsetToken}`);
+      console.log(`  Rows inserted:      ${status.rowsInsertedCount}`);
+      console.log(`  Rows errored:       ${status.rowsErrorCount}`);
+      console.log(`  Avg server latency: ${status.serverAvgProcessingLatencyMs} ms`);
+      if (status.rowsErrorCount > 0) {
+        console.log(`  Last error:         ${status.lastErrorMessage}`);
+      }
     } finally {
       await channel.close();
     }

--- a/nodejs-example/streaming_ingest_example.js
+++ b/nodejs-example/streaming_ingest_example.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Example demonstrating how to use the Snowflake Streaming Ingest SDK in
+ * Node.js with the high-performance architecture and default pipe.
+ *
+ * The default pipe is automatically created by Snowflake when you first
+ * open a channel. No CREATE PIPE DDL is required. The default pipe name
+ * follows the convention: <TABLE_NAME>-STREAMING
+ */
+
+"use strict";
+
+const crypto = require("node:crypto");
+const { createClient } = require("snowpipe-streaming");
+
+const MAX_ROWS = 100_000;
+
+// Replace these with your Snowflake object names
+const DATABASE = "MY_DATABASE";
+const SCHEMA = "MY_SCHEMA";
+const TABLE = "MY_TABLE";
+
+// Default pipe: Snowflake auto-creates this on first channel open
+const PIPE = `${TABLE}-STREAMING`;
+
+async function main() {
+  // Create Snowflake Streaming Ingest Client
+  const client = await createClient({
+    clientName: `MY_CLIENT_${crypto.randomUUID()}`,
+    dbName: DATABASE,
+    schemaName: SCHEMA,
+    pipeName: PIPE,
+    profilePath: "profile.json",
+  });
+
+  console.log("Client created successfully");
+
+  try {
+    // Open a channel for data ingestion
+    const { channel } = await client.openChannel({
+      name: `MY_CHANNEL_${crypto.randomUUID()}`,
+    });
+
+    console.log(`Channel opened: ${channel.channelName}`);
+
+    try {
+      // Ingest rows — column names must match the target table schema.
+      // The default pipe uses MATCH_BY_COLUMN_NAME to map fields.
+      console.log(`Ingesting ${MAX_ROWS} rows...`);
+      for (let i = 1; i <= MAX_ROWS; i++) {
+        const rowId = String(i);
+        await channel.appendRow(
+          {
+            c1: i,
+            c2: rowId,
+            ts: new Date(),
+          },
+          rowId,
+        );
+
+        if (i % 10_000 === 0) {
+          console.log(`Ingested ${i} rows...`);
+        }
+      }
+
+      console.log("All rows submitted. Waiting for ingestion to complete...");
+
+      // Wait for all rows to be committed
+      const expectedToken = String(MAX_ROWS);
+      await channel.waitForCommit(
+        (token) => token !== null && token === expectedToken,
+        { timeoutMs: 60_000 },
+      );
+
+      // Verify channel status
+      const status = await channel.getChannelStatus();
+      console.log(
+        `Latest committed offset token: ${status.latestCommittedOffsetToken}`,
+      );
+      console.log("All data committed successfully");
+    } finally {
+      await channel.close();
+    }
+
+    console.log("Data ingestion completed");
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("Error during data ingestion:", err.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Add a complete Node.js example for the Snowpipe Streaming SDK alongside the existing Java and Python examples
- Uses `snowpipe-streaming` npm package with `profilePath`-based auth, `waitForCommit` for offset verification, and try/finally cleanup
- Update top-level README to include Node.js in the list of examples

## Test plan
- [x] Run `npm install` and `node streaming_ingest_example.js` against a Snowflake account
- [x] Verify 100,000 rows are committed and offset token is printed
- [x] Confirm channel and client close cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)