### PR TITLE
Use wait_for_commit and get_channel_status in main examples

### DIFF
--- a/java-example/README.md
+++ b/java-example/README.md
@@ -82,7 +82,7 @@ mvn exec:java
    - `c1`: Integer counter
    - `c2`: String representation of the counter
    - `ts`: Current timestamp
-4. **Waits for Completion** - Polls the channel status until all data is committed
+4. **Waits for Completion** - Uses `waitForCommit()` to block until all rows are committed, then calls `getChannelStatus()` to display committed offset, rows inserted, error count, and server latency
 5. **Closes Resources** - Properly closes the channel and client via try-with-resources
 
 ## Expected Output
@@ -94,9 +94,12 @@ Ingesting 100000 rows...
 Ingested 10000 rows...
 Ingested 20000 rows...
 ...
-All rows submitted. Waiting for ingestion to complete...
-Latest offset token: 100000
-All data committed successfully
+All rows submitted. Waiting for commit...
+All data committed. Channel status:
+  Committed offset:   100000
+  Rows inserted:      100000
+  Rows errored:       0
+  Avg server latency: PT1.234S
 Data ingestion completed
 ```
 

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -99,7 +99,7 @@ All data committed. Channel status:
   Committed offset:   100000
   Rows inserted:      100000
   Rows errored:       0
-  Avg server latency: PT1.234S
+  Avg server latency: 1234 ms
 Data ingestion completed
 ```
 

--- a/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/MonitorAbortExample.java
+++ b/java-example/monitoring/src/main/java/com/snowflake/example/monitoring/MonitorAbortExample.java
@@ -20,7 +20,7 @@ import java.util.UUID;
  * and automatically halting production when server-side errors are detected.
  *
  * <p>This example mirrors the Python monitor_abort_example.py and uses the
- * SSv2 high-performance architecture API:
+ * Snowpipe Streaming high-performance architecture API:
  * <ul>
  *   <li>{@code appendRow()} - fire-and-forget row append (server-side validation)</li>
  *   <li>{@code getChannelStatus()} - rich status with error counts, latency, committed offset</li>

--- a/java-example/src/main/java/com/snowflake/example/StreamingIngestExample.java
+++ b/java-example/src/main/java/com/snowflake/example/StreamingIngestExample.java
@@ -2,6 +2,7 @@ package com.snowflake.example;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snowflake.ingest.streaming.ChannelStatus;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
@@ -9,11 +10,12 @@ import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Example demonstrating how to use the Snowflake Streaming Ingest SDK
@@ -27,8 +29,6 @@ public class StreamingIngestExample {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String PROFILE_PATH = "profile.json";
     private static final int MAX_ROWS = 100_000;
-    private static final int POLL_ATTEMPTS = 30;
-    private static final long POLL_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
 
     // Replace these with your Snowflake object names
     private static final String DATABASE = "MY_DATABASE";
@@ -80,30 +80,32 @@ public class StreamingIngestExample {
                         }
                     }
 
-                    System.out.println("All rows submitted. Waiting for ingestion to complete...");
+                    System.out.println("All rows submitted. Waiting for commit...");
 
-                    // Wait for ingestion to complete
-                    for (int attempt = 1; attempt <= POLL_ATTEMPTS; attempt++) {
-                        String latestOffset = channel.getChannelStatus().getLatestOffsetToken();
-                        System.out.println("Latest offset token: " + latestOffset);
+                    // Wait for all rows to be committed using waitForCommit.
+                    // The predicate receives the latest committed offset token
+                    // (String) and should return true when satisfied.
+                    channel.waitForCommit(
+                        token -> token != null && Long.parseLong(token) >= MAX_ROWS,
+                        Duration.ofSeconds(30)
+                    ).get();
 
-                        if (latestOffset != null && Integer.parseInt(latestOffset) >= MAX_ROWS) {
-                            System.out.println("All data committed successfully");
-                            break;
-                        }
-
-                        if (attempt == POLL_ATTEMPTS) {
-                            throw new RuntimeException("Ingestion failed after all attempts");
-                        }
-
-                        Thread.sleep(POLL_INTERVAL_MS);
+                    // Now that data has landed, check the channel status
+                    ChannelStatus status = channel.getChannelStatus();
+                    System.out.println("All data committed. Channel status:");
+                    System.out.println("  Committed offset:   " + status.getLatestOffsetToken());
+                    System.out.println("  Rows inserted:      " + status.getRowsInsertedCount());
+                    System.out.println("  Rows errored:       " + status.getRowsErrorCount());
+                    System.out.println("  Avg server latency: " + status.getServerAvgProcessingLatency());
+                    if (status.getRowsErrorCount() > 0) {
+                        System.out.println("  Last error:         " + status.getLastErrorMessage());
                     }
                 } // Channel automatically closed here
 
                 System.out.println("Data ingestion completed");
             } // Client automatically closed here
 
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException | InterruptedException | ExecutionException e) {
             System.err.println("Error during data ingestion: " + e.getMessage());
             e.printStackTrace();
             System.exit(1);

--- a/java-example/src/main/java/com/snowflake/example/StreamingIngestExample.java
+++ b/java-example/src/main/java/com/snowflake/example/StreamingIngestExample.java
@@ -96,7 +96,7 @@ public class StreamingIngestExample {
                     System.out.println("  Committed offset:   " + status.getLatestOffsetToken());
                     System.out.println("  Rows inserted:      " + status.getRowsInsertedCount());
                     System.out.println("  Rows errored:       " + status.getRowsErrorCount());
-                    System.out.println("  Avg server latency: " + status.getServerAvgProcessingLatency());
+                    System.out.println("  Avg server latency: " + status.getServerAvgProcessingLatency().toMillis() + " ms");
                     if (status.getRowsErrorCount() > 0) {
                         System.out.println("  Last error:         " + status.getLastErrorMessage());
                     }

--- a/python-example/README.md
+++ b/python-example/README.md
@@ -91,7 +91,7 @@ python streaming_ingest_example.py
    - `c1`: Integer counter
    - `c2`: String representation of the counter
    - `ts`: Current timestamp
-4. **Waits for Completion** - Polls the channel status until all data is committed
+4. **Waits for Completion** - Uses `wait_for_commit()` to block until all rows are committed, then calls `get_channel_status()` to display committed offset, rows inserted, error count, and server latency
 5. **Closes Resources** - Properly closes the channel and client via context managers
 
 ## Expected Output
@@ -103,9 +103,12 @@ Ingesting 100000 rows...
 Ingested 10000 rows...
 Ingested 20000 rows...
 ...
-All rows submitted. Waiting for ingestion to complete...
-Latest offset token: 99999
-All data committed successfully
+All rows submitted. Waiting for commit...
+All data committed. Channel status:
+  Committed offset:   100000
+  Rows inserted:      100000
+  Rows errored:       0
+  Avg server latency: 0:00:01.234000
 Data ingestion completed
 ```
 

--- a/python-example/README.md
+++ b/python-example/README.md
@@ -108,7 +108,7 @@ All data committed. Channel status:
   Committed offset:   100000
   Rows inserted:      100000
   Rows errored:       0
-  Avg server latency: 0:00:01.234000
+  Avg server latency: 1.234 s
 Data ingestion completed
 ```
 

--- a/python-example/streaming_ingest_example.py
+++ b/python-example/streaming_ingest_example.py
@@ -8,7 +8,6 @@ follows the convention: <TABLE_NAME>-STREAMING
 """
 
 from datetime import datetime
-import time
 import uuid
 import os
 
@@ -19,8 +18,6 @@ from snowflake.ingest.streaming import StreamingIngestClient
 
 
 MAX_ROWS = 100_000
-POLL_ATTEMPTS = 30
-POLL_INTERVAL_MS = 1000
 
 # Replace these with your Snowflake object names
 DATABASE = "MY_DATABASE"
@@ -52,7 +49,7 @@ def main():
             # Ingest rows — column names must match the target table schema.
             # The default pipe uses MATCH_BY_COLUMN_NAME to map fields.
             print(f"Ingesting {MAX_ROWS} rows...")
-            for i in range(MAX_ROWS):
+            for i in range(1, MAX_ROWS + 1):
                 row_id = str(i)
                 channel.append_row(
                     {
@@ -63,23 +60,28 @@ def main():
                     row_id
                 )
 
-                if (i + 1) % 10_000 == 0:
-                    print(f"Ingested {i + 1} rows...")
+                if i % 10_000 == 0:
+                    print(f"Ingested {i} rows...")
 
-            print("All rows submitted. Waiting for ingestion to complete...")
+            print("All rows submitted. Waiting for commit...")
 
-            # Wait for ingestion to complete
-            for attempt in range(POLL_ATTEMPTS):
-                latest_offset = channel.get_latest_committed_offset_token()
-                print(f"Latest offset token: {latest_offset}")
+            # Wait for all rows to be committed using wait_for_commit.
+            # The predicate receives the latest committed offset token
+            # (str or None) and should return True when satisfied.
+            def all_rows_committed(token):
+                return token is not None and int(token) >= MAX_ROWS
 
-                if latest_offset == str(MAX_ROWS - 1):
-                    print("All data committed successfully")
-                    break
+            channel.wait_for_commit(all_rows_committed, timeout_seconds=30)
 
-                time.sleep(POLL_INTERVAL_MS / 1000)
-            else:
-                raise Exception("Ingestion failed after all attempts")
+            # Now that data has landed, check the channel status
+            status = channel.get_channel_status()
+            print(f"All data committed. Channel status:")
+            print(f"  Committed offset:   {status.latest_committed_offset_token}")
+            print(f"  Rows inserted:      {status.rows_inserted_count}")
+            print(f"  Rows errored:       {status.rows_error_count}")
+            print(f"  Avg server latency: {status.server_avg_processing_latency}")
+            if status.rows_error_count > 0:
+                print(f"  Last error:         {status.last_error_message}")
 
         # Channel automatically closed here
         print("Data ingestion completed")

--- a/python-example/streaming_ingest_example.py
+++ b/python-example/streaming_ingest_example.py
@@ -79,7 +79,7 @@ def main():
             print(f"  Committed offset:   {status.latest_committed_offset_token}")
             print(f"  Rows inserted:      {status.rows_inserted_count}")
             print(f"  Rows errored:       {status.rows_error_count}")
-            print(f"  Avg server latency: {status.server_avg_processing_latency}")
+            print(f"  Avg server latency: {status.server_avg_processing_latency.total_seconds():.3f} s")
             if status.rows_error_count > 0:
                 print(f"  Last error:         {status.last_error_message}")
 


### PR DESCRIPTION
## Summary

- Replace manual polling loops with `wait_for_commit()` / `waitForCommit()` in both Python and Java main examples
- After data lands, call `get_channel_status()` / `getChannelStatus()` to display committed offset, rows inserted, rows errored, and avg server latency
- Align Python to 1-indexed offsets matching Java (both now send offsets 1 to 100000)
- Fix SSv2 reference in Java monitoring example Javadoc

## Test plan

- [x] Python example runs successfully against live Snowflake account
- [x] Java example runs successfully against live Snowflake account
- [x] Java compiles cleanly (`mvn compile`)
- [x] Both examples display channel status after commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)